### PR TITLE
Implement a wrapper to run jug with gridmap

### DIFF
--- a/gridmap/__init__.py
+++ b/gridmap/__init__.py
@@ -73,6 +73,7 @@ from gridmap.conf import (CHECK_FREQUENCY, CREATE_PLOTS, DEFAULT_QUEUE,
                           NUM_RESUBMITS, SEND_ERROR_MAIL, SMTP_SERVER,
                           USE_MEM_FREE)
 from gridmap.job import Job, JobException, process_jobs, grid_map
+from gridmap.jug import grid_jug
 from gridmap.version import __version__, VERSION
 
 # For * imports

--- a/gridmap/jug.py
+++ b/gridmap/jug.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from gridmap.job import grid_map
+import jug.jug
 
-def grid_jug(jug_args, jug_nworkers=100, **kwargs):
+
+def grid_jug(jug_args, jug_nworkers=4, name='gridjug', **kwargs):
     """
     A light-weight wrapper to run jug with gridmap on a Grid Engine cluster
     """
-
-    from gridmap.job import grid_map
 
     jug_argv = ['dummy_script_name_not_parsed_by_jug', 'execute']
     jug_argv.extend(jug_args)
@@ -35,6 +36,7 @@ def grid_jug(jug_args, jug_nworkers=100, **kwargs):
     return grid_map(
         f=_jug_main,
         args_list=args_list,
+        name=name,
         **kwargs
     )
 
@@ -43,7 +45,4 @@ def _jug_main(*args, **kwargs):
     """
     wrapper function for pickle
     """
-
-    from jug.jug import main
-
-    return main(*args, **kwargs)
+    return jug.jug.main(*args, **kwargs)

--- a/gridmap/jug.py
+++ b/gridmap/jug.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from gridmap.job import grid_map
 import jug.jug
 
 
@@ -9,6 +8,8 @@ def grid_jug(jug_args, jug_nworkers=4, name='gridjug', **kwargs):
     A light-weight wrapper to run jug with gridmap on a Grid Engine cluster
     """
 
+    from gridmap.job import grid_map
+    
     jug_argv = ['dummy_script_name_not_parsed_by_jug', 'execute']
     jug_argv.extend(jug_args)
 

--- a/gridmap/jug.py
+++ b/gridmap/jug.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+
+def grid_jug(jug_args, jug_nworkers=100, **kwargs):
+    """
+    A light-weight wrapper to run jug with gridmap on a Grid Engine cluster
+    """
+
+    from gridmap.job import grid_map
+
+    jug_argv = ['dummy_script_name_not_parsed_by_jug', 'execute']
+    jug_argv.extend(jug_args)
+
+    # function arguments for grid_map
+    # note that there are multiple lists here
+    # the innermost list is the list of arguments to jug
+    # this needs to stay a list as jug.main accepts a single argument argv
+    # which is a list of parameters for jug
+    # https://github.com/luispedro/jug/blob/15a7043f6f859810b5e6af1638176d1a9cb70f5a/jug/jug.py#L405
+    #
+    # we wrap this inner list in a wrapper list [jug_argv] that gridmap
+    # "expands" to its single item jug_argv upon calling the jug.main function,
+    # with that very single item jug_argv as the single argument
+    # https://github.com/pygridtools/gridmap/blob/master/gridmap/job.py#L225
+    #
+    # finally, the wrapper list [jug_arvg] is contained in the outer list
+    # [[jug_argv]]. The outer list is multiplied by the number of workers to
+    # create an outer list of that many items, each of which is the wrapped
+    # list [jug_argv] to supplied to each of the worker jobs
+    # https://github.com/pygridtools/gridmap/blob/master/gridmap/job.py#L929
+    # https://github.com/pygridtools/gridmap/blob/master/gridmap/job.py#L933
+    #
+    args_list = jug_nworkers * [[jug_argv]]
+
+    return grid_map(
+        f=_jug_main,
+        args_list=args_list,
+        **kwargs
+    )
+
+
+def _jug_main(*args, **kwargs):
+    """
+    wrapper function for pickle
+    """
+
+    from jug.jug import main
+
+    return main(*args, **kwargs)


### PR DESCRIPTION
A light-weight wrapper to run jug with gridmap on a Grid Engine cluster

Get the best of both worlds of **gridmap** and **jug**
* http://pythonhosted.org/Jug/
* http://gridmap.readthedocs.org/en/latest/

This implements gridmap.grid_jug to run jug jobs with all the comfortable features of gridmap.

As I am not sure whether this belongs into the gridmap or the jug package, I create a pull request for both to foster discussion between the two projects.
The file jug/grid.py is identical with the file gridmap/jug.py .