### PR TITLE
Modify function module check to allow partial object

### DIFF
--- a/gridmap/__init__.py
+++ b/gridmap/__init__.py
@@ -31,6 +31,8 @@ in a more 'pythonic' fashion.
                    will use via mem_free? (Default: ``False``)
 :var DEFAULT_QUEUE: The default job scheduling queue to use.
                     (Default: ``all.q``)
+:var DEFAULT_TEMP_DIR: The default temporary directory for job output.
+                       (Default: ``/scratch/``)
 :var CREATE_PLOTS: Should we plot cpu and mem usage and send via email?
                    (Default: ``True``)
 :var SEND_ERROR_MAIL: Should we send error emails?
@@ -71,7 +73,7 @@ from gridmap.conf import (CHECK_FREQUENCY, CREATE_PLOTS, DEFAULT_QUEUE,
                           HEARTBEAT_FREQUENCY, IDLE_THRESHOLD,
                           MAX_IDLE_HEARTBEATS, MAX_TIME_BETWEEN_HEARTBEATS,
                           NUM_RESUBMITS, SEND_ERROR_MAIL, SMTP_SERVER,
-                          USE_MEM_FREE)
+                          USE_MEM_FREE, DEFAULT_TEMP_DIR)
 from gridmap.job import Job, JobException, process_jobs, grid_map
 from gridmap.version import __version__, VERSION
 
@@ -80,4 +82,5 @@ __all__ = ['Job', 'JobException', 'process_jobs', 'grid_map', 'CHECK_FREQUENCY',
            'CREATE_PLOTS', 'DEFAULT_QUEUE', 'ERROR_MAIL_RECIPIENT',
            'ERROR_MAIL_SENDER', 'HEARTBEAT_FREQUENCY', 'IDLE_THRESHOLD',
            'MAX_IDLE_HEARTBEATS', 'MAX_TIME_BETWEEN_HEARTBEATS',
-           'NUM_RESUBMITS', 'SEND_ERROR_MAIL', 'SMTP_SERVER', 'USE_MEM_FREE']
+           'NUM_RESUBMITS', 'SEND_ERROR_MAIL', 'SMTP_SERVER', 'USE_MEM_FREE',
+           'DEFAULT_TEMP_DIR']

--- a/gridmap/conf.py
+++ b/gridmap/conf.py
@@ -127,3 +127,6 @@ USE_MEM_FREE = 'TRUE' == os.getenv('USE_MEM_FREE', 'False').upper()
 
 # Which queue should we use by default
 DEFAULT_QUEUE = os.getenv('DEFAULT_QUEUE', 'all.q')
+
+# Where shall we use as temporary_directory
+DEFAULT_TEMP_DIR = os.getenv('DEFAULT_TEMP_DIR', '/scratch/')

--- a/gridmap/job.py
+++ b/gridmap/job.py
@@ -43,6 +43,7 @@ import os
 import smtplib
 import sys
 import traceback
+import functools
 from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -200,8 +201,9 @@ class Job(object):
         except TypeError:
             self.path = ''
 
-        # if module is not __main__, all is good
-        if m.__name__ != "__main__":
+        # if module is not __main__, all is good. If the function is a
+        #   partial function we'll take it as is also.
+        if isinstance(f, functools.partial) or m.__name__ != "__main__":
             self._f = f
 
         else:

--- a/gridmap/job.py
+++ b/gridmap/job.py
@@ -62,7 +62,8 @@ from gridmap.conf import (CHECK_FREQUENCY, CREATE_PLOTS, DEFAULT_QUEUE,
                           ERROR_MAIL_SENDER, HEARTBEAT_FREQUENCY,
                           IDLE_THRESHOLD, MAX_IDLE_HEARTBEATS,
                           MAX_TIME_BETWEEN_HEARTBEATS, NUM_RESUBMITS,
-                          SEND_ERROR_MAIL, SMTP_SERVER, USE_MEM_FREE)
+                          SEND_ERROR_MAIL, SMTP_SERVER, USE_MEM_FREE,
+                          DEFAULT_TEMP_DIR)
 from gridmap.data import zdumps, zloads
 from gridmap.runner import _heart_beat
 
@@ -266,7 +267,7 @@ class JobMonitor(object):
     """
     Job monitor that communicates with other nodes via 0MQ.
     """
-    def __init__(self, temp_dir='/scratch'):
+    def __init__(self, temp_dir=DEFAULT_TEMP_DIR):
         """
         set up socket
         """
@@ -662,7 +663,7 @@ def send_error_mail(job):
         os.unlink(img_mem_fn)
 
 
-def handle_resubmit(session_id, job, temp_dir='/scratch/'):
+def handle_resubmit(session_id, job, temp_dir=DEFAULT_TEMP_DIR):
     """
     heuristic to determine if the job should be resubmitted
 
@@ -735,7 +736,7 @@ def _process_jobs_locally(jobs, max_processes=1):
     return jobs
 
 
-def _submit_jobs(jobs, home_address, temp_dir='/scratch', white_list=None,
+def _submit_jobs(jobs, home_address, temp_dir=DEFAULT_TEMP_DIR, white_list=None,
                  quiet=True):
     """
     Method used to send a list of jobs onto the cluster.
@@ -772,7 +773,7 @@ def _submit_jobs(jobs, home_address, temp_dir='/scratch', white_list=None,
     return sid
 
 
-def _append_job_to_session(session, job, temp_dir='/scratch/', quiet=True):
+def _append_job_to_session(session, job, temp_dir=DEFAULT_TEMP_DIR, quiet=True):
     """
     For an active session, append new job based on information stored in job
     object. Also sets job.id to the ID of the job on the grid.
@@ -829,7 +830,7 @@ def _append_job_to_session(session, job, temp_dir='/scratch/', quiet=True):
     session.deleteJobTemplate(jt)
 
 
-def process_jobs(jobs, temp_dir='/scratch/', white_list=None, quiet=True,
+def process_jobs(jobs, temp_dir=DEFAULT_TEMP_DIR, white_list=None, quiet=True,
                  max_processes=1, local=False):
     """
     Take a list of jobs and process them on the cluster.
@@ -905,7 +906,7 @@ def _resubmit(session_id, job, temp_dir):
 # MapReduce Interface
 #####################
 def grid_map(f, args_list, cleanup=True, mem_free="1G", name='gridmap_job',
-             num_slots=1, temp_dir='/scratch/', white_list=None,
+             num_slots=1, temp_dir=DEFAULT_TEMP_DIR, white_list=None,
              queue=DEFAULT_QUEUE, quiet=True, local=False, max_processes=1,
              interpreting_shell=None, copy_env=True, completion_mail=False):
     """

--- a/tests/test_gridmap.py
+++ b/tests/test_gridmap.py
@@ -22,16 +22,18 @@ Some simple unit tests for GridMap.
 
 from __future__ import division, print_function, unicode_literals
 
+import os
 import logging
 from datetime import datetime
 from multiprocessing import Pool
+from operator import add
+from functools import partial
 
 import gridmap
 from gridmap import (Job, process_jobs, grid_map, HEARTBEAT_FREQUENCY,
                      MAX_TIME_BETWEEN_HEARTBEATS)
 
 from nose.tools import eq_
-
 
 # Setup logging
 logging.captureWarnings(True)
@@ -82,6 +84,24 @@ def test_map():
 
 def test_map_local():
     yield check_map, 0, True
+
+
+# Create a simple partial object and test as above
+add_two = partial(add, 2)
+
+def check_map_partial(local):
+    inputs = [1, 2, 4, 6, 8, 16]
+    expected = [x + 2 for x in inputs]
+    outputs = grid_map(add_two, inputs, quiet=False, local=local)
+    eq_(expected, outputs)
+
+
+def test_map_partial():
+    yield check_map_partial, False
+
+
+def test_map_partial_local():
+    yield check_map_partial, True
 
 
 def make_jobs(inputvec, function):


### PR DESCRIPTION
The checks in Job.function() stop partial objects being used.
    if m.__name__ != "__main__":
        self._f = f

The proposed modification allows gridmap to work with a functools.partial object.