### PR TITLE
Support for -pe (parallel environment) option

### DIFF
--- a/gridmap/conf.py
+++ b/gridmap/conf.py
@@ -130,3 +130,6 @@ DEFAULT_QUEUE = os.getenv('DEFAULT_QUEUE', 'all.q')
 
 # Where shall we use as temporary_directory
 DEFAULT_TEMP_DIR = os.getenv('DEFAULT_TEMP_DIR', '/scratch/')
+
+# Which parallel environment to use by default
+DEFAULT_PE = "smp"

--- a/gridmap/conf.py
+++ b/gridmap/conf.py
@@ -132,4 +132,4 @@ DEFAULT_QUEUE = os.getenv('DEFAULT_QUEUE', 'all.q')
 DEFAULT_TEMP_DIR = os.getenv('DEFAULT_TEMP_DIR', '/scratch/')
 
 # Which parallel environment to use by default
-DEFAULT_PE = "smp"
+DEFAULT_PE = os.getenv('DEFAULT_PE', "smp")

--- a/gridmap/conf.py
+++ b/gridmap/conf.py
@@ -62,6 +62,8 @@ specifying environment variables with the same name.
 :var HEARTBEAT_FREQUENCY: How many seconds pass before jobs on the cluster send
                           back heart beats to the submission host.
                           (Default: 10)
+:var DEFAULT_PAR_ENV: Default parallel environment to use 
+                      (Default: ``smp``)
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -132,4 +134,4 @@ DEFAULT_QUEUE = os.getenv('DEFAULT_QUEUE', 'all.q')
 DEFAULT_TEMP_DIR = os.getenv('DEFAULT_TEMP_DIR', '/scratch/')
 
 # Which parallel environment to use by default
-DEFAULT_PE = os.getenv('DEFAULT_PE', "smp")
+DEFAULT_PAR_ENV = os.getenv('DEFAULT_PAR_ENV', "smp")

--- a/gridmap/job.py
+++ b/gridmap/job.py
@@ -149,7 +149,7 @@ class Job(object):
                         Overwrites variables which already exist due to
                         ``copy_env=True``.
         :type add_env: dict
-        :param par_env: parallel environment to use. default is "smp"
+        :param par_env: parallel environment to use.
         :type par_env: str
         """
         self.track_mem = []
@@ -981,6 +981,8 @@ def grid_map(f, args_list, cleanup=True, mem_free="1G", name='gridmap_job',
                     Overwrites variables which already exist due to
                     ``copy_env=True``.
     :type add_env: dict
+    :param par_env: parallel environment to use.
+    :type par_env: str
     :param completion_mail: whether to send an e-mail upon completion of all
                             jobs
     :type completion_mail: boolean

--- a/gridmap/job.py
+++ b/gridmap/job.py
@@ -63,7 +63,7 @@ from gridmap.conf import (CHECK_FREQUENCY, CREATE_PLOTS, DEFAULT_QUEUE,
                           IDLE_THRESHOLD, MAX_IDLE_HEARTBEATS,
                           MAX_TIME_BETWEEN_HEARTBEATS, NUM_RESUBMITS,
                           SEND_ERROR_MAIL, SMTP_SERVER, USE_MEM_FREE,
-                          DEFAULT_TEMP_DIR, DEFAULT_PE)
+                          DEFAULT_TEMP_DIR, DEFAULT_PAR_ENV)
 from gridmap.data import zdumps, zloads
 from gridmap.runner import _heart_beat
 
@@ -116,11 +116,11 @@ class Job(object):
                  'cause_of_death', 'num_resubmits', 'home_address',
                  'log_stderr_fn', 'log_stdout_fn', 'timestamp', 'host_name',
                  'heart_beat', 'track_mem', 'track_cpu', 'interpreting_shell',
-                 'copy_env','pe')
+                 'copy_env','par_env')
 
     def __init__(self, f, args, kwlist=None, cleanup=True, mem_free="1G",
                  name='gridmap_job', num_slots=1, queue=DEFAULT_QUEUE,
-                 interpreting_shell=None, copy_env=True, add_env=None, pe=DEFAULT_PE):
+                 interpreting_shell=None, copy_env=True, add_env=None, par_env=DEFAULT_PAR_ENV):
         """
         Initializes a new Job.
 
@@ -149,8 +149,8 @@ class Job(object):
                         Overwrites variables which already exist due to
                         ``copy_env=True``.
         :type add_env: dict
-        :param pe: parallel environment to use. default is "smp"
-        :type pe: str
+        :param par_env: parallel environment to use. default is "smp"
+        :type par_env: str
         """
         self.track_mem = []
         self.track_cpu = []
@@ -197,7 +197,7 @@ class Job(object):
         if add_env is not None:
             _add_env(add_env)
         self.working_dir = os.getcwd()
-        self.pe = pe
+        self.par_env = par_env
 
     @property
     def function(self):
@@ -266,7 +266,7 @@ class Job(object):
         if self.mem_free and USE_MEM_FREE:
             ret += " -l mem_free={}".format(self.mem_free)
         if self.num_slots and self.num_slots > 1:
-            ret += " -pe {} {}".format(self.pe, self.num_slots)
+            ret += " -pe {} {}".format(self.par_env, self.num_slots)
         if self.white_list:
             ret += " -l h={}".format('|'.join(self.white_list))
         if self.queue:
@@ -932,7 +932,7 @@ def grid_map(f, args_list, cleanup=True, mem_free="1G", name='gridmap_job',
              num_slots=1, temp_dir=DEFAULT_TEMP_DIR, white_list=None,
              queue=DEFAULT_QUEUE, quiet=True, local=False, max_processes=1,
              interpreting_shell=None, copy_env=True, add_env=None,
-             completion_mail=False, require_cluster=False, pe=DEFAULT_PE):
+             completion_mail=False, require_cluster=False, par_env=DEFAULT_PAR_ENV):
     """
     Maps a function onto the cluster.
 
@@ -996,7 +996,7 @@ def grid_map(f, args_list, cleanup=True, mem_free="1G", name='gridmap_job',
                 cleanup=cleanup, mem_free=mem_free,
                 name='{}{}'.format(name, job_num), num_slots=num_slots,
                 queue=queue, interpreting_shell=interpreting_shell,
-                copy_env=copy_env, add_env=add_env, pe=pe)
+                copy_env=copy_env, add_env=add_env, par_env=par_env)
             for job_num, args in enumerate(args_list)]
 
     # process jobs


### PR DESCRIPTION
Thanks for this really great package!
However, it breaks on the cluster I am using when num_slots > 1: I get an error
```
drmaa.errors.DeniedByDrmException: code 17: job rejected: the requested parallel environment "smp" does not exist
```
The problem is the `-pe smp <num_slots>` that is appended to the job submission (line 266 of job.py). My cluster requires `-pe openmp <num_slots>` instead.

This pull request fixes this by making a small change, allowing the user to specify the parallel environment.